### PR TITLE
Apply Groom Modifiers Extension

### DIFF
--- a/send2ue/resources/extensions/apply_groom_modifiers.py
+++ b/send2ue/resources/extensions/apply_groom_modifiers.py
@@ -3,8 +3,6 @@ from send2ue.core import utilities
 from send2ue.constants import ToolInfo
 from send2ue.core.extension import ExtensionBase
 
-hair_object_copies = []
-
 # Get or create temp collection (necessary?) 
 def get_temp_collection(collection_name="GroomTempCollection"):
     if collection_name in bpy.data.collections:
@@ -15,21 +13,16 @@ def get_temp_collection(collection_name="GroomTempCollection"):
     
     return temp_collection
 
-# make copies of original objects, link to temp collection, and store for removal later
-# Now that I think about it, storing isn't necessary since I can just grab objects from temp collection
-# I will change later - JoshQuake
+# make copies of original objects, link to temp collection
 def apply_groom_modifiers():
     properties = bpy.context.scene.send2ue
     hair_objects = utilities.get_hair_objects(properties)
     temp_collection = get_temp_collection()
 
-    hair_object_copies.clear()
-
     for hair_object in hair_objects:
         hair_copy = hair_object.copy()
         hair_copy.data = hair_object.data.copy()
         temp_collection.objects.link(hair_copy)
-        hair_object_copies.append(hair_copy)
 
         for modifier in hair_object.modifiers:
             bpy.context.view_layer.objects.active = hair_object
@@ -41,8 +34,9 @@ def apply_groom_modifiers():
 def restore_groom_modifiers():
     temp_collection = get_temp_collection()
     export_collection = bpy.data.collections.get(ToolInfo.EXPORT_COLLECTION.value)
+    hair_copies = temp_collection.all_objects
 
-    for hair_copy in hair_object_copies:
+    for hair_copy in hair_copies:
         original_name = hair_copy.name.split(".")[0]
         modified_hair_object = bpy.data.objects.get(original_name)
         if modified_hair_object:
@@ -51,7 +45,6 @@ def restore_groom_modifiers():
             temp_collection.objects.unlink(hair_copy)
             hair_copy.name = original_name
 
-    hair_object_copies.clear()
     bpy.data.collections.remove(temp_collection)
 
 class ApplyGroomModifiersExtension(ExtensionBase):

--- a/send2ue/resources/extensions/apply_groom_modifiers.py
+++ b/send2ue/resources/extensions/apply_groom_modifiers.py
@@ -1,0 +1,81 @@
+import bpy
+from send2ue.core import utilities
+from send2ue.constants import ToolInfo
+from send2ue.core.extension import ExtensionBase
+
+hair_object_copies = []
+
+# Get or create temp collection (necessary?) 
+def get_temp_collection(collection_name="GroomTempCollection"):
+    if collection_name in bpy.data.collections:
+        temp_collection = bpy.data.collections[collection_name]
+    else:
+        temp_collection = bpy.data.collections.new(name=collection_name)
+        bpy.context.scene.collection.children.link(temp_collection)
+    
+    return temp_collection
+
+# make copies of original objects, link to temp collection, and store for removal later
+# Now that I think about it, storing isn't necessary since I can just grab objects from temp collection
+# I will change later - JoshQuake
+def apply_groom_modifiers():
+    properties = bpy.context.scene.send2ue
+    hair_objects = utilities.get_hair_objects(properties)
+    temp_collection = get_temp_collection()
+
+    hair_object_copies.clear()
+
+    for hair_object in hair_objects:
+        hair_copy = hair_object.copy()
+        hair_copy.data = hair_object.data.copy()
+        temp_collection.objects.link(hair_copy)
+        hair_object_copies.append(hair_copy)
+
+        for modifier in hair_object.modifiers:
+            bpy.context.view_layer.objects.active = hair_object
+            print(modifier.name)
+            if modifier.name != 'Surface Deform':
+                bpy.ops.object.modifier_apply(modifier=modifier.name)
+
+# Delete modified objects and restore original copies
+def restore_groom_modifiers():
+    temp_collection = get_temp_collection()
+    export_collection = bpy.data.collections.get(ToolInfo.EXPORT_COLLECTION.value)
+
+    for hair_copy in hair_object_copies:
+        original_name = hair_copy.name.split(".")[0]
+        modified_hair_object = bpy.data.objects.get(original_name)
+        if modified_hair_object:
+            bpy.data.objects.remove(modified_hair_object, do_unlink=True)
+            export_collection.objects.link(hair_copy)
+            temp_collection.objects.unlink(hair_copy)
+            hair_copy.name = original_name
+
+    hair_object_copies.clear()
+    bpy.data.collections.remove(temp_collection)
+
+class ApplyGroomModifiersExtension(ExtensionBase):
+    name = 'applygroommodifiers'
+
+    apply_groom_mods: bpy.props.BoolProperty(
+        name= "Apply Groom Mods",
+        default= False,
+        description="Automatically applies hair modifiers for export "
+                    "Modifiers restored after export finishes."
+    )
+
+    # Draws setting in extensions panel.
+    def draw_export(self, dialog, layout, properties):
+        box = layout.box()
+        box.label(text='Groom Modifiers:')
+        dialog.draw_property(self, box, 'apply_groom_mods')
+
+    def pre_operation(self, properties):
+        if self.apply_groom_mods:
+            print('groommods enabled')
+            apply_groom_modifiers()
+
+    def post_operation(self, properties):
+        if self.apply_groom_mods:
+            print('groommods post')
+            restore_groom_modifiers()

--- a/send2ue/resources/setting_templates/default.json
+++ b/send2ue/resources/setting_templates/default.json
@@ -66,6 +66,9 @@
   "export_custom_property_fcurves": true,
   "export_object_name_as_root": true,
   "extensions": {
+    "applygroommodifiers": {
+      "apply_groom_mods": true
+    },
     "affixes": {
       "animation_sequence_name_affix": "Anim_",
       "auto_add_asset_name_affixes": false,

--- a/tests/test_files/send2ue_templates/default.json
+++ b/tests/test_files/send2ue_templates/default.json
@@ -66,6 +66,9 @@
   "export_custom_property_fcurves": true,
   "export_object_name_as_root": true,
   "extensions": {
+    "applygroommodifiers": {
+      "apply_groom_mods": true
+    },
     "affixes": {
       "animation_sequence_name_affix": "Anim_",
       "auto_add_asset_name_affixes": false,

--- a/tests/test_files/send2ue_templates/template_1.json
+++ b/tests/test_files/send2ue_templates/template_1.json
@@ -66,6 +66,9 @@
   "export_custom_property_fcurves": true,
   "export_object_name_as_root": true,
   "extensions": {
+    "applygroommodifiers": {
+      "apply_groom_mods": true
+    },
     "affixes": {
       "animation_sequence_name_affix": "Anim_",
       "auto_add_asset_name_affixes": false,


### PR DESCRIPTION
First implementation of an extension that automatically applies groom modifiers on export.

Automatically applies modifiers to hair before export, and restores them after export. Makes it easier for those that utilize a guide curve with interpolated child curve modifiers workflow.

Needs optimization but its working for me. Feedback and testing necessary before I merge.

Referencing issue:
https://github.com/EpicGamesExt/BlenderTools/issues/718